### PR TITLE
Fix gulp-bem-src source

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "dependencies": {
     "bem-bundle": "^0.2.0",
-    "gulp-bem-src": "gulp-bem/gulp-bem-src#511ad0b",
+    "gulp-bem-src": "gulp-bem/gulp-bem-src#specs",
     "merge2": "^1.0.2",
     "node-eval": "^1.0.3",
     "through2": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "dependencies": {
     "bem-bundle": "^0.2.0",
-    "gulp-bem-src": "gulp-bem/gulp-bem-src#specs",
+    "gulp-bem-src": "gulp-bem/gulp-bem-src#add_deps_as_dep",
     "merge2": "^1.0.2",
     "node-eval": "^1.0.3",
     "through2": "^2.0.1",


### PR DESCRIPTION
`npm i` failing with error when tried to install gulp-bem-src package due to unknown revision in package.json for it.
Here is the fix of unknown revision gulp-bem/gulp-bem-src#511ad0b to spec branch.
